### PR TITLE
Refactor asyncStringReplacer

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "prepare-release": "run-s reset-hard test cov:check doc:html version doc:publish"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=16.6.0"
   },
   "dependencies": {
     "@bitauth/libauth": "^1.18.1",

--- a/src/lib/util/utils.ts
+++ b/src/lib/util/utils.ts
@@ -1,4 +1,19 @@
 /**
+ * @param match The matched substring.
+ * @param offset The offset of the matched substring within the whole string being examined. (For example, if the whole string was 'abcd', and the matched substring was 'bc', then this argument will be 1.)
+ * @param string The whole string being examined.
+ * @param groups In browser versions supporting named capturing groups, will be an object whose keys are the used group names, and whose values are the matched portions (undefined if not matched).
+ * @param capturedGroups An object of named capturing groups whose keys are the names and values are the capturing groups or undefined if no named capturing groups were defined. See [Groups and Ranges](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges) for more information.
+ * @returns {string|Promise<string>}
+ */
+ type asyncStringReplacerFn = (
+  match: string,
+  offset: number | undefined,
+  string: string,
+  groups?: { [key: string]: string },
+  ...capturedGroups: Array<string>
+) => string | Promise<string>;
+/**
  * @param stringToReplace The string that'll be replaced
  * @param regex The regex used to match the string, using the global flag "g" is recommended
  * @param callback replacerFunction, this function will be called for every match for the regex and replace it with the result of the callback
@@ -6,18 +21,44 @@
 export async function asyncStringReplacer(
   stringToReplace: string,
   regex: RegExp,
-  callback: (str: string) => string | Promise<string>
+  // TODO add string parameters
+  callback: asyncStringReplacerFn
 ): Promise<string | null> {
   const matched = stringToReplace.match(regex);
-  //If stringToReplace doesn't have a codeblock, return null
+  //If stringToReplace doesn't have a code block, return null
   if (!matched) return null;
-  //Format the matched strings according to the callback
-  const formatted = await Promise.all(matched.map(callback));
-  const result = matched.reduce((prev, curr, ind) => {
-    //The string with the matched values replaced with it's corresponding "formatted string"
-    return prev.replace(curr, formatted[ind]);
-  }, stringToReplace);
-  return result;
+  if (regex.global) {
+    const matches = matched.map((val) => {
+      const singleMatched = val.match(new RegExp(regex.source));
+      // Not possible since it only loops through the matches but for typesript
+      if (!singleMatched) return val;
+      const [match, ...capturedGroup] = singleMatched;
+      return callback(
+        match,
+        singleMatched.index,
+        stringToReplace,
+        singleMatched.groups,
+        ...capturedGroup
+      );
+    });
+    const formatted = await Promise.all(matches);
+
+    const result = matched.reduce((prev, curr, ind) => {
+      //The string with the matched values replaced with it's corresponding "formatted string"
+      return prev.replace(curr, formatted[ind]);
+    }, stringToReplace);
+    return result;
+  } else {
+    const [match, ...capturedGroup] = matched;
+    const replacedValue = await callback(
+      match,
+      matched.index,
+      stringToReplace,
+      matched.groups,
+      ...capturedGroup
+    );
+    return stringToReplace.replace(match, replacedValue);
+  }
 }
 
 /**

--- a/src/lib/util/utils.ts
+++ b/src/lib/util/utils.ts
@@ -27,11 +27,14 @@ export async function asyncStringReplacer(
   const matched = stringToReplace.match(regex);
   //If stringToReplace doesn't have a code block, return null
   if (!matched) return null;
+  // If it's a global regex
   if (regex.global) {
     const matches = matched.map((val) => {
+      // Create a non-global regex from the provided regex  
       const singleMatched = val.match(new RegExp(regex.source));
       // Not possible since it only loops through the matches but for typesript
       if (!singleMatched) return val;
+      // The first element is the matched substring, the others are the capture groups 
       const [match, ...capturedGroup] = singleMatched;
       return callback(
         match,
@@ -41,15 +44,17 @@ export async function asyncStringReplacer(
         ...capturedGroup
       );
     });
+    // Use the callback to get an array of results for each matches
     const formatted = await Promise.all(matches);
 
     const result = matched.reduce((prev, curr, ind) => {
-      //The string with the matched values replaced with it's corresponding "formatted string"
+      // The string with the matched values replaced with it's corresponding "formatted string"
       return prev.replace(curr, formatted[ind]);
     }, stringToReplace);
     return result;
   } else {
     const [match, ...capturedGroup] = matched;
+    // Format the string according to the callback
     const replacedValue = await callback(
       match,
       matched.index,

--- a/src/lib/util/utils.ts
+++ b/src/lib/util/utils.ts
@@ -19,28 +19,29 @@ export async function asyncStringReplacer(
   }, stringToReplace);
   return result;
 }
+
 /**
  *
  * @param str The single line string that'll be added comments to
  * @param language The language identifier for the specific style of comments
  * @returns The line as a comment, if the language key isn't provided or isn't supported it just returns the original string
  */
-export function commentify(str: string, language?: string): string {
+ export function commentify(str: string, language?: string): string {
   switch (language) {
     case 'js':
     case 'javascript':
     case 'typescript':
     case 'ts':
-      return '//' + str;
+      return '// ' + str;
     case 'jsx':
     case 'tsx':
     case 'css':
-      return '/*' + str + '*/';
+      return '/* ' + str + ' */';
     case 'html':
-      return '<!--' + str + '-->';
+      return '<!-- ' + str + ' -->';
     case 'python':
     case 'py':
-      return '#' + str;
+      return '# ' + str;
     default:
       return str;
   }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fixes and feature enhancements

- **What is the current behavior?** (You can also link to an open issue here)

1.  Cancels when coming across an unformattable code snippet, even if there are multiple code blocks
2.  Keeps empty code blocks 
3. Sets `firstLanguageKey` to invalid languages

- **What is the new behavior (if this is a feature change)?**

_NEW BEHAVIOR_

1. Cancels only when *all* the code blocks are unformattable, carries on formatting other code blocks even after reaching an unformattable one
2. Removes empty code blocks only from the result (the message the bot sends. not the codes sent on pastebin)
3. Changed `firstLanguageKey` to only be set should the provided language be *valid/supported*
4. Adds a "language specific comment" on unformattable blocks saying "Could not format this snippet"

_Code refactoring_
- Adds spacings to `commentify`
- Refactors `asyncStringReplacer` to be more like the actual [<String>.replace](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/string/replace)
- Refactors implementation of `asyncStringReplacer` to match the new method
- Updates package.json's engines, nodejs' minimum version has been changed from 10 to 16.6.0 (since discord.js v13 now needs v16.6.0)

- **Other information**:
The comments on the "original code " and the "prettied code" sent on pastebin still needs work, especially for multi-lined language-less/invalid-language-including code blocks

I would upload tests but I use jest
 
 I am working on the comments issue right now