### PR TITLE
Fixed minor formatting bugs

### DIFF
--- a/src/lib/util/FormatMessage.ts
+++ b/src/lib/util/FormatMessage.ts
@@ -6,6 +6,7 @@ import { asyncStringReplacer, commentify } from './utils';
 
 export const formatMessage = async (
   message: Message,
+  //TODO add onlyCodeBlocks feature
   _onlyCodeBlocks?: boolean
 ) => {
   const content = message.content;

--- a/src/lib/util/FormatMessage.ts
+++ b/src/lib/util/FormatMessage.ts
@@ -1,20 +1,20 @@
 import { Message } from 'discord.js';
-import {
-  languageMappings,
-  languageNameMappings,
-} from '../formatters/FormatterMappings';
+import { languageMappings } from '../formatters/FormatterMappings';
 import { UploadToPastecord } from '../infra/external/pastecordintegration';
 import { reformat } from './reformatter';
 import { asyncStringReplacer, commentify } from './utils';
 
-export const formatMessage = async (message: Message) => {
+export const formatMessage = async (
+  message: Message,
+  _onlyCodeBlocks?: boolean
+) => {
   const content = message.content;
   // The first language key found, it'll be used for the pastecord file and all the comments on the file
-  let firstLanguageKey: string | undefined;
+  let firstLanguageKey: string | undefined = content.match(
+    new RegExp(`\`\`\`(${Object.keys(languageMappings).join('|')})\n`, 'm')
+  )?.[1];
   // The message's content with the code blocks and their contents removed
   let contentWithoutCode = content;
-  // The content that'll be uploaded to pastecord
-  let pastecordCode = content;
   // Should the content be too large to upload, the formatted code will be sent through pastecord and this will be the content
   let prettiedPastecordCode = content;
   // The amount of code blocks in the content
@@ -32,26 +32,38 @@ export const formatMessage = async (message: Message) => {
         // For one liners
         if (language.trim() && !languageMappings[language]) {
           unformattableCodeBlockCounter++;
+          const commented = commentify(match, firstLanguageKey);
+          contentWithoutCode = contentWithoutCode.replace(match, '\n');
+          // Replace this line with it's commented version 
+          prettiedPastecordCode = prettiedPastecordCode.replace(
+            match,
+            commented
+          );
+          // returning match itself means nothing will be changed
           return match;
         }
         // For empty codeblocks, remove the content
         unformattableCodeBlockCounter++;
+        // Returning '' will completely remove the empty code block
         return '';
       }
-      // If firstLanguage is undefined and language is a valid languagekey, it sets the value
-      if (!firstLanguageKey && languageNameMappings[language])
-        firstLanguageKey = language.trim();
       const theCode = codeContent.trim();
-      // Remove the entire code block
-      contentWithoutCode = contentWithoutCode.replace(match, '\n');
-      // Remove the code block formatting and adds it's content
-      pastecordCode = pastecordCode.replace(match, '\n' + codeContent + '\n');
       const languageFormatter = languageMappings[language];
       // If "language" is undefined or unsupported for formatting, return the original code block with it's content
       if (!languageFormatter) {
         unformattableCodeBlockCounter++;
+        // This is for unsupported multi line code blocks, each line gets commented and replaced to be sent on the pastecord
+        const commented = match
+          .split('\n')
+          .map((val) => commentify(val, firstLanguageKey))
+          .join('\n');
+        contentWithoutCode = contentWithoutCode.replace(match, '\n');
+        prettiedPastecordCode = prettiedPastecordCode.replace(match, commented);
+        // returning match itself means nothing will be changed
         return match;
       }
+      // Remove the entire code block
+      contentWithoutCode = contentWithoutCode.replace(match, '\n');
       // Format the code, if it's unformattable, return null
       const formattedCode = await languageFormatter
         .format(theCode)
@@ -73,7 +85,7 @@ export const formatMessage = async (message: Message) => {
         );
       }
       //Replace the string's code with the formatted code inside a code block
-      return match.replace(theCode, formattedCode);
+      return match.replace(codeContent, '\n' + formattedCode.trim() + '\n');
     }
   );
   if (!prettifiedCode) {
@@ -83,22 +95,20 @@ export const formatMessage = async (message: Message) => {
   if (unformattableCodeBlockCounter === codeBlockCounter)
     throw new Error('No Formattable code block');
 
-  pastecordCode = contentWithoutCode.split('\n').reduce((prev, curr) => {
-    // Return the previous value should the element be "" instead of adding empty comments
-    if (curr === '') return prev;
-    return prev.replace(curr, commentify(curr, firstLanguageKey));
-  }, pastecordCode);
-
   // This is what the bot will send
-  // The max character limit for discord message contents is 2000
   let replyContent = prettifiedCode;
+  // The max character limit for discord message contents is 2000
   if (replyContent.length > 1999) {
     prettiedPastecordCode = contentWithoutCode
       .split('\n')
-      .reduce((prev, curr) => {
+      .reduce((prev, curr, ind) => {
         // Return the previous value should the element be "" instead of adding empty comments
-        if (curr === '') return prev;
-        return prev.replace(curr, commentify(curr, firstLanguageKey));
+        if (curr.trim() === '') return prev;
+        // For non code block content, if it's the first line, it shouldn't start with \n
+        return prev.replace(
+          (ind === 0 ? '' : '\n') + curr,
+          '\n' + commentify(curr, firstLanguageKey)
+        );
       }, prettiedPastecordCode);
     // The formatted code to be sent to pastecord
     const prettyPasteCord = await UploadToPastecord(


### PR DESCRIPTION
### READY TO TEST AND MERGE 👍🏻
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix, feature
- **What is the current behavior?** (You can also link to an open issue here)

1. [botched indentation](https://github.com/tatupesonen/formatbot/issues/10) if the original content has excess indentation
2. For the pastecord code, this doesn't add comments/adds it in an unexpected way for multi line codeblock content
- **What is the new behavior (if this is a feature change)?**
Fixes the issues mentioned above
~~adds option to have only the codeblock content (not yet implemented)~~ ( Pushed to a later commit )
- **Other information**:
fixes #10 