### PR TITLE
Fix pastecord link issue

### DIFF
--- a/src/lib/infra/pastecordintegration.ts
+++ b/src/lib/infra/pastecordintegration.ts
@@ -6,10 +6,10 @@ interface PastecordResponse {
 }
 
 export class PastecordImplementation implements IUploader {
-  constructor(private readonly url = 'https://pastecord.com/documents') {}
+  constructor(private readonly url = 'https://pastecord.com') {}
   async upload(content: string, languageKey?: string): Promise<string> {
     const { data }: AxiosResponse<PastecordResponse> = await axios.post(
-      this.url,
+      this.url + '/documents',
       content
     );
     const urlEnd = languageKey ? `.${languageKey}` : '';


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix
- **What is the current behavior?** (You can also link to an open issue here)
currently this sends`pastecord.com/document/filename` instead of  `pastecord.com/filename` this was mentioned on and this fixes #26 
- **What is the new behavior (if this is a feature change)?**
the issue mentioned above has been fixed
- **Other information**:
