### PR TITLE
refactor(core): move formatting logic to FormatService

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { PastecordImplementation } from './lib/infra/pastecordintegration';
 import { IDetector } from './lib/interfaces/IDetector';
 import { IParser } from './lib/interfaces/IParser';
 import { IUploader } from './lib/interfaces/IUploader';
+import { FormatService } from './lib/service/FormatService';
 import { GuesslangDetector } from './lib/util/Detector';
 import { Parser } from './lib/util/MessageParser';
 
@@ -19,6 +20,8 @@ const bootstrap = async () => {
   container.set<IUploader>(new PastecordImplementation(), DITypes.uploader);
   container.set<IDetector>(new GuesslangDetector(), DITypes.detector);
   container.set<IParser>(new Parser(), DITypes.parser);
+  const formatService = new FormatService(container);
+  container.set<FormatService>(formatService, DITypes.formatService);
   const { client: bot } = await createBot(container);
   container.set<Client>(bot, DITypes.client);
   bot.login(process.env.DISCORD_TOKEN);

--- a/src/lib/commands/format.ts
+++ b/src/lib/commands/format.ts
@@ -1,23 +1,15 @@
 import { InteractionReplyOptions } from 'discord.js';
 import { DITypes } from '../container/container';
-import {
-  languageMappings,
-  languageNameMappings,
-} from '../formatters/FormatterMappings';
 import { ICommand, COMMAND_TYPE } from '../interfaces/ICommand';
-import { IDetector } from '../interfaces/IDetector';
-import { IParser } from '../interfaces/IParser';
-import { reformat } from '../util/reformatter';
-import { checkIfLanguageSupported, commentify } from '../util/utils';
+import { FormatService } from '../service/FormatService';
 
 const FormatCommand: ICommand<COMMAND_TYPE.SLASH> = {
   name: 'Format',
   description: '',
   type: COMMAND_TYPE.SLASH,
   async execute(interaction, container) {
-    // Get parser
-    const parser = container.getByKey<IParser>(DITypes.parser);
-    const detector = container.getByKey<IDetector>(DITypes.detector);
+    // Get service
+    const service = container.getByKey<FormatService>(DITypes.formatService);
     const baseReply: InteractionReplyOptions = { ephemeral: true };
     await interaction.deferReply(baseReply);
     // Parse package.json first
@@ -25,87 +17,8 @@ const FormatCommand: ICommand<COMMAND_TYPE.SLASH> = {
       const message = await interaction.channel.messages.fetch(
         interaction.targetId
       );
-      const blocks = parser.parseMessage(message.toString());
-      if (blocks.length === 0)
-        return interaction.editReply({
-          ...baseReply,
-          content: "Couldn't find any code blocks in this message.",
-        });
-      // Find formatter and try to format
-      const formattedBlocks = await Promise.all(
-        blocks.map(async (block) => {
-          let formattedBlock;
-          let detectedLanguageKey;
-          if (block.languageKey) {
-            try {
-              formattedBlock = await languageMappings[block.languageKey].format(
-                block.content
-              );
-            } catch (err) {
-              const comment = commentify(
-                `Couldn't format this ${
-                  languageNameMappings[block.languageKey]
-                } snippet. Perhaps there's a syntax error?`,
-                block.languageKey
-              );
-              formattedBlock = `${comment}\n${block.content}`;
-            }
-          } else {
-            // Attempt detecting the language
-            const { langKey, fullLangName } = await detector.detect(
-              block.content
-            );
-            detectedLanguageKey = langKey;
-            if (detectedLanguageKey) {
-              // One last attempt at formatting
-              // Check if the language is supported
-              const isSupported = checkIfLanguageSupported(detectedLanguageKey);
-              if (isSupported) {
-                try {
-                  formattedBlock = await languageMappings[
-                    detectedLanguageKey
-                  ].format(block.content);
-                } catch (err) {
-                  const comment = commentify(
-                    `Couldn't format this snippet. Perhaps there's a syntax error, or maybe the detector made a mistake?${
-                      fullLangName
-                        ? ` Detected language: ${
-                            languageNameMappings[detectedLanguageKey]
-                              ? languageNameMappings[detectedLanguageKey]
-                              : fullLangName
-                          }`
-                        : ''
-                    }`
-                  );
-                  // Formatting failed, set detectedLanguageKey to null.
-                  detectedLanguageKey = null;
-                  formattedBlock = `${comment}\n${block.content}`;
-                }
-              }
-            } else {
-              const comment = commentify(
-                `Couldn't find a compatible formatter for this code block. ${
-                  fullLangName
-                    ? `detected language: ${
-                        languageNameMappings[detectedLanguageKey]
-                          ? languageNameMappings[detectedLanguageKey]
-                          : fullLangName
-                      }`
-                    : "Couldn't detect a language."
-                }`
-              );
-              formattedBlock = `${comment}\n${block.content}`;
-            }
-          }
-          let reformatLangKey = block.languageKey
-            ? block.languageKey
-            : detectedLanguageKey;
-          reformatLangKey ??= '';
-          return reformat(formattedBlock, reformatLangKey);
-        })
-      );
-      const reply = formattedBlocks.join('');
-      interaction.editReply({ ...baseReply, content: reply });
+      const formatted = await service.format(message.toString());
+      interaction.editReply({ ...baseReply, content: formatted });
     } catch (err) {
       interaction.editReply({
         ...baseReply,

--- a/src/lib/container/container.ts
+++ b/src/lib/container/container.ts
@@ -4,6 +4,7 @@ export const DITypes = {
   detector: 'detector',
   client: 'client',
   parser: 'parser',
+  formatService: 'formatService',
 } as const;
 
 export type Constr<T> = new (...args: unknown[]) => T;

--- a/src/lib/service/FormatService.ts
+++ b/src/lib/service/FormatService.ts
@@ -1,0 +1,98 @@
+import { Container, DITypes } from '../container/container';
+import {
+  languageMappings,
+  languageNameMappings,
+} from '../formatters/FormatterMappings';
+import { IDetector } from '../interfaces/IDetector';
+import { IParser } from '../interfaces/IParser';
+import { reformat } from '../util/reformatter';
+import { checkIfLanguageSupported, commentify } from '../util/utils';
+
+export class FormatService {
+  constructor(private readonly container: Container) {}
+
+  public async format(message: string): Promise<string> {
+    const parser = this.container.getByKey<IParser>(DITypes.parser);
+    const detector = this.container.getByKey<IDetector>(DITypes.detector);
+
+    const blocks = parser.parseMessage(message);
+    if (blocks.length === 0)
+      return "Couldn't find any code blocks in this message.";
+
+    // Find formatter and try to format
+    const formattedBlocks = await Promise.all(
+      blocks.map(async (block) => {
+        let formattedBlock;
+        let detectedLanguageKey;
+        if (block.languageKey) {
+          try {
+            formattedBlock = await languageMappings[block.languageKey].format(
+              block.content
+            );
+          } catch (err) {
+            const comment = commentify(
+              `Couldn't format this ${
+                languageNameMappings[block.languageKey]
+              } snippet. Perhaps there's a syntax error?`,
+              block.languageKey
+            );
+            formattedBlock = `${comment}\n${block.content}`;
+          }
+        } else {
+          // Attempt detecting the language
+          const { langKey, fullLangName } = await detector.detect(
+            block.content
+          );
+          detectedLanguageKey = langKey;
+          if (detectedLanguageKey) {
+            // One last attempt at formatting
+            // Check if the language is supported
+            const isSupported = checkIfLanguageSupported(detectedLanguageKey);
+            if (isSupported) {
+              try {
+                formattedBlock = await languageMappings[
+                  detectedLanguageKey
+                ].format(block.content);
+              } catch (err) {
+                const comment = commentify(
+                  `Couldn't format this snippet. Perhaps there's a syntax error, or maybe the detector made a mistake?${
+                    fullLangName
+                      ? ` Detected language: ${
+                          languageNameMappings[detectedLanguageKey]
+                            ? languageNameMappings[detectedLanguageKey]
+                            : fullLangName
+                        }`
+                      : ''
+                  }`
+                );
+                // Formatting failed, set detectedLanguageKey to null.
+                detectedLanguageKey = null;
+                formattedBlock = `${comment}\n${block.content}`;
+              }
+            }
+          } else {
+            const comment = commentify(
+              `Couldn't find a compatible formatter for this code block. ${
+                fullLangName
+                  ? `detected language: ${
+                      languageNameMappings[detectedLanguageKey]
+                        ? languageNameMappings[detectedLanguageKey]
+                        : fullLangName
+                    }`
+                  : "Couldn't detect a language."
+              }`
+            );
+            formattedBlock = `${comment}\n${block.content}`;
+          }
+        }
+        let reformatLangKey = block.languageKey
+          ? block.languageKey
+          : detectedLanguageKey;
+        reformatLangKey ??= '';
+        return reformat(formattedBlock, reformatLangKey);
+      })
+    );
+    const reply = formattedBlocks.join('');
+    return reply;
+  }
+}


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Decouples formatting logic to it's own service that can be reused.

- **What is the current behavior?** (You can also link to an open issue here)
- Formatting logic is localized to the Format command