### PR TITLE
feat(core): implement conditional arguments for commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ package-lock.json
 .env
 .DS_Store
 temp/
+.devcontainer

--- a/src/lib/bot.ts
+++ b/src/lib/bot.ts
@@ -1,11 +1,20 @@
 import { Client, Intents } from 'discord.js';
 import { readdirSync } from 'fs';
-import { COMMAND_TYPE, ICommand } from './interfaces/ICommand';
+import { COMMAND_TYPE, Command } from './interfaces/ICommand';
 import StatusCommand from './commands/status';
 import { Container } from './container/container';
 import { logger } from './util/logger';
 
-export const COMMANDS: Record<string, ICommand<COMMAND_TYPE>> = {};
+export const COMMANDS: Record<
+  string,
+  // Using `unknown | any` because the type of args are not known here
+  // when narrowing down, `unknown` would allow for string arguments
+  // and `any` would allow for any other type of arguments.
+  // Technically just `any` would do the job too, but it is not 100% accurate.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Command<COMMAND_TYPE, [unknown | any]>
+> = {};
+
 export const createBot = async (container: Container) => {
   // Let's load all the commands.
   const commandFiles = readdirSync(`${__dirname}/commands`);
@@ -35,7 +44,7 @@ export const createBot = async (container: Container) => {
     logger.warn(`Removed from guild! ${guild.name}, ${guild.id}`);
   });
 
-  client.on('messageCreate', (message) => {
+  client.on('messageCreate', async (message) => {
     if (message.author.bot) return;
     // Special case for bot mentions
     if (
@@ -51,13 +60,21 @@ export const createBot = async (container: Container) => {
     // User is bot operator
     // Get message args
     const args = message.content.slice(prefix.length).trim().split(/ +/);
-    const [command, ...commandArgs] = args;
+    const [commandName, ...commandArgs] = args;
     // Find command from args and run execute
-    if (COMMANDS[command]) {
-      return COMMANDS[command].execute(message, container, commandArgs);
+    const command = COMMANDS[commandName];
+
+    if (command.type !== COMMAND_TYPE.LEGACY) return;
+
+    if (typeof command.resolveArgs === 'function') {
+      const resolvedArgs = await command.resolveArgs(message, commandArgs);
+
+      return command.execute(message, resolvedArgs, container);
+    } else if (command) {
+      return command.execute(message, commandArgs, container);
     }
     logger.warn(
-      `${message.author.username}: [${message.author.id}] tried to run nonexistent command ${prefix}${command}`
+      `${message.author.username}: [${message.author.id}] tried to run nonexistent command ${prefix}${commandName}`
     );
   });
 

--- a/src/lib/commands/deploy.ts
+++ b/src/lib/commands/deploy.ts
@@ -7,10 +7,10 @@ const DeployCommand: Command<COMMAND_TYPE.LEGACY> = {
   name: 'deploy',
   description: "Deploys the bot's slash commands and context menus",
   type: COMMAND_TYPE.LEGACY,
-  async execute(interaction, container) {
+  async execute(message, container) {
     // Get dependencies
     const client = container.getByKey<Client>('client');
-    if (interaction.author.id !== process.env.OWNER) return;
+    if (message.author.id !== process.env.OWNER) return;
     const slashCommands: ApplicationCommandData[] = Object.entries(COMMANDS)
       .filter(
         ([_, value]) =>
@@ -22,7 +22,7 @@ const DeployCommand: Command<COMMAND_TYPE.LEGACY> = {
         return acc;
       }, []);
     await client.application.commands.set(slashCommands);
-    interaction.reply(`Registered ${slashCommands.length} commands.`);
+    message.reply(`Registered ${slashCommands.length} commands.`);
   },
 };
 

--- a/src/lib/commands/deploy.ts
+++ b/src/lib/commands/deploy.ts
@@ -1,9 +1,9 @@
 import { ApplicationCommandData, Client } from 'discord.js';
 import { COMMANDS } from '../bot';
 
-import { ICommand, COMMAND_TYPE } from '../interfaces/ICommand';
+import { Command, COMMAND_TYPE } from '../interfaces/ICommand';
 
-const DeployCommand: ICommand<COMMAND_TYPE.LEGACY> = {
+const DeployCommand: Command<COMMAND_TYPE.LEGACY> = {
   name: 'deploy',
   description: "Deploys the bot's slash commands and context menus",
   type: COMMAND_TYPE.LEGACY,

--- a/src/lib/commands/format.ts
+++ b/src/lib/commands/format.ts
@@ -1,9 +1,9 @@
 import { InteractionReplyOptions } from 'discord.js';
 import { DITypes } from '../container/container';
-import { ICommand, COMMAND_TYPE } from '../interfaces/ICommand';
+import { Command, COMMAND_TYPE } from '../interfaces/ICommand';
 import { FormatService } from '../service/FormatService';
 
-const FormatCommand: ICommand<COMMAND_TYPE.SLASH> = {
+const FormatCommand: Command<COMMAND_TYPE.SLASH> = {
   name: 'Format',
   description: '',
   type: COMMAND_TYPE.SLASH,

--- a/src/lib/commands/formatSlash.ts
+++ b/src/lib/commands/formatSlash.ts
@@ -1,10 +1,10 @@
-import { InteractionReplyOptions } from 'discord.js';
+import { InteractionReplyOptions, Message } from 'discord.js';
 import { DITypes } from '../container/container';
 import { languageMappings } from '../formatters/FormatterMappings';
-import { COMMAND_TYPE, ICommand } from '../interfaces/ICommand';
+import { COMMAND_TYPE, Command } from '../interfaces/ICommand';
 import { FormatService } from '../service/FormatService';
 
-const FormatSlashCommand: ICommand<COMMAND_TYPE.CHANNEL> = {
+const FormatSlashCommand: Command<COMMAND_TYPE.CHANNEL> = {
   name: 'format',
   type: COMMAND_TYPE.CHANNEL,
   description: "Formats a message that's given as an argument",
@@ -51,7 +51,7 @@ const FormatSlashCommand: ICommand<COMMAND_TYPE.CHANNEL> = {
       //       "Sorry, I don't support the programming language you gave to me. Yet :)",
       //   });
       // Check that inputlanguage is in
-      let message;
+      let message: Message;
       try {
         message = await interaction.channel.messages.fetch(targetMessage);
       } catch (err) {

--- a/src/lib/commands/help.ts
+++ b/src/lib/commands/help.ts
@@ -5,7 +5,7 @@ const HelpCommand: Command<COMMAND_TYPE.LEGACY> = {
   name: 'help',
   description: 'Shows help information',
   type: COMMAND_TYPE.LEGACY,
-  async execute(interaction) {
+  async execute(message) {
     const embed: Partial<MessageEmbed> = {
       fields: [
         {
@@ -22,7 +22,7 @@ const HelpCommand: Command<COMMAND_TYPE.LEGACY> = {
         },
       ],
     };
-    interaction.reply({ embeds: [embed] });
+    message.reply({ embeds: [embed] });
   },
 };
 

--- a/src/lib/commands/help.ts
+++ b/src/lib/commands/help.ts
@@ -1,7 +1,7 @@
 import { MessageEmbed } from 'discord.js';
-import { ICommand, COMMAND_TYPE } from '../interfaces/ICommand';
+import { Command, COMMAND_TYPE } from '../interfaces/ICommand';
 
-const HelpCommand: ICommand<COMMAND_TYPE.LEGACY> = {
+const HelpCommand: Command<COMMAND_TYPE.LEGACY> = {
   name: 'help',
   description: 'Shows help information',
   type: COMMAND_TYPE.LEGACY,

--- a/src/lib/commands/status.ts
+++ b/src/lib/commands/status.ts
@@ -6,7 +6,7 @@ const StatusCommand: Command<COMMAND_TYPE.LEGACY> = {
   name: 'status',
   description: "Shows FormatBot's status",
   type: COMMAND_TYPE.LEGACY,
-  async execute(interaction, container) {
+  async execute(message, container) {
     // Get dependencies
     const client = container.getByKey<Client>('client');
 
@@ -66,7 +66,7 @@ const StatusCommand: Command<COMMAND_TYPE.LEGACY> = {
         },
       ],
     };
-    interaction.reply({ embeds: [embed] });
+    message.reply({ embeds: [embed] });
   },
 };
 

--- a/src/lib/commands/status.ts
+++ b/src/lib/commands/status.ts
@@ -1,8 +1,8 @@
 import { intervalToDuration } from 'date-fns';
 import { Client, MessageEmbed } from 'discord.js';
-import { ICommand, COMMAND_TYPE } from '../interfaces/ICommand';
+import { Command, COMMAND_TYPE } from '../interfaces/ICommand';
 
-const StatusCommand: ICommand<COMMAND_TYPE.LEGACY> = {
+const StatusCommand: Command<COMMAND_TYPE.LEGACY> = {
   name: 'status',
   description: "Shows FormatBot's status",
   type: COMMAND_TYPE.LEGACY,

--- a/src/lib/util/createCommand.ts
+++ b/src/lib/util/createCommand.ts
@@ -1,5 +1,10 @@
 import { COMMAND_TYPE, Command } from '../interfaces/ICommand';
 
-export const createCommand = <T extends COMMAND_TYPE>(cmd: Command<T>) => {
+export const createCommand = <
+  TCommandType extends typeof COMMAND_TYPE[keyof typeof COMMAND_TYPE],
+  TArgs = void
+>(
+  cmd: Command<TCommandType, TArgs>
+) => {
   return cmd;
 };

--- a/src/lib/util/createCommand.ts
+++ b/src/lib/util/createCommand.ts
@@ -1,5 +1,5 @@
-import { COMMAND_TYPE, ICommand } from '../interfaces/ICommand';
+import { COMMAND_TYPE, Command } from '../interfaces/ICommand';
 
-export const createCommand = <T extends COMMAND_TYPE>(cmd: ICommand<T>) => {
+export const createCommand = <T extends COMMAND_TYPE>(cmd: Command<T>) => {
   return cmd;
 };


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
Feature

- **What is the current behavior?**
See https://github.com/tatupesonen/formatbot/issues/42

- **What is the new behavior (if this is a feature change)?**
This PR allows for different ways of creating legacy commands in a fully type-safe, also applied some small refactorings
```typescript
// Legacy commands

// Without args
const command: Command<COMMAND_TYPE.LEGACY> = {
  name: "hello",
  description: "hello",
  type: COMMAND_TYPE.LEGACY,
  async execute(message, container) {
    message // Message
    container // Container
  }
}

// With args
const command: Command<COMMAND_TYPE.LEGACY, [GuildMember]> = {
  name: "hello",
  description: "hello",
  type: COMMAND_TYPE.LEGACY,
  resolveArgs: async (message, args) => [
    await message.guild.members.fetch(args[0]),
  ],
  async execute(message, [member], container) {
    message // Message
    member // GuildMember
    container // Container
  }
}
```

- **Other information**:
I added `.devcontainer` to `.gitignore` since I quickly created a dev container to work on this PR, it was not plug and play, hence I excluded it
