### PR TITLE
HTTPSify the google chart endpoint

### DIFF
--- a/src/lib/service/LaTeXService.ts
+++ b/src/lib/service/LaTeXService.ts
@@ -10,7 +10,7 @@ export class LaTeXService {
   public async format(texContent: string): Promise<string> {
     const encodedTexContent = encodeURIComponent(texContent);
 
-    const url = `http://chart.apis.google.com/chart?cht=tx&chs=60&chf=bg,s,${DISCORD_BG_COLOR}&chco=FFFFFF&chl=${encodedTexContent}`;
+    const url = `https://chart.apis.google.com/chart?cht=tx&chs=60&chf=bg,s,${DISCORD_BG_COLOR}&chco=FFFFFF&chl=${encodedTexContent}`;
     logger.debug(`Requesting ${url}...`);
     return url;
   }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
"bug"fix.

- **What is the current behavior?** (You can also link to an open issue here)
Returns a non-https endpoint.

- **What is the new behavior (if this is a feature change)?**
Now returns the same endpoint but with https rather than HTTP.

- **Other information**:
n/a 