### PR TITLE
feat: use native typings for command declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@unibeautify/beautifier-prettydiff": "^0.6.0",
     "axios": "^0.21.1",
     "date-fns": "^2.23.0",
-    "discord.js": "^13.1.0",
+    "discord.js": "^13.3.1",
     "dotenv": "^10.0.0",
     "prettier": "^2.3.2",
     "prettydiff2": "^2.2.8",

--- a/src/lib/commands/deploy.ts
+++ b/src/lib/commands/deploy.ts
@@ -1,29 +1,23 @@
-import { ApplicationCommandData, Client } from 'discord.js';
+import { Client } from 'discord.js';
 import { COMMANDS } from '../bot';
+import { ContextMenuCommand, SlashCommand } from '../interfaces/ICommand';
+import { createCommand } from '../util/createCommand';
 
-import { Command, COMMAND_TYPE } from '../interfaces/ICommand';
-
-const DeployCommand: Command<COMMAND_TYPE.LEGACY> = {
+export default createCommand({
   name: 'deploy',
   description: "Deploys the bot's slash commands and context menus",
-  type: COMMAND_TYPE.LEGACY,
-  async execute(message, container) {
+  type: 'LEGACY',
+  async execute(message, _args, container) {
     // Get dependencies
     const client = container.getByKey<Client>('client');
     if (message.author.id !== process.env.OWNER) return;
-    const slashCommands: ApplicationCommandData[] = Object.entries(COMMANDS)
-      .filter(
-        ([_, value]) =>
-          value.type === COMMAND_TYPE.CHANNEL ||
-          value.type === COMMAND_TYPE.SLASH
-      )
-      .reduce((acc, cur) => {
-        acc.push(cur[1]);
-        return acc;
-      }, []);
-    await client.application.commands.set(slashCommands);
-    message.reply(`Registered ${slashCommands.length} commands.`);
-  },
-};
 
-export default DeployCommand;
+    const nonLegacyCommands = Object.values(COMMANDS).filter(
+      (command): command is ContextMenuCommand | SlashCommand =>
+        command.type !== 'LEGACY'
+    );
+
+    await client.application.commands.set(nonLegacyCommands);
+    message.reply(`Registered ${nonLegacyCommands.length} commands.`);
+  },
+});

--- a/src/lib/commands/format.ts
+++ b/src/lib/commands/format.ts
@@ -1,12 +1,12 @@
 import { InteractionReplyOptions } from 'discord.js';
 import { DITypes } from '../container/container';
-import { Command, COMMAND_TYPE } from '../interfaces/ICommand';
 import { FormatService } from '../service/FormatService';
+import { createCommand } from '../util/createCommand';
 
-const FormatCommand: Command<COMMAND_TYPE.SLASH> = {
+export default createCommand({
   name: 'Format',
   description: '',
-  type: COMMAND_TYPE.SLASH,
+  type: 'CHAT_INPUT',
   async execute(interaction, container) {
     // Get service
     const service = container.getByKey<FormatService>(DITypes.formatService);
@@ -15,7 +15,7 @@ const FormatCommand: Command<COMMAND_TYPE.SLASH> = {
     // Parse package.json first
     try {
       const message = await interaction.channel.messages.fetch(
-        interaction.targetId
+        interaction.user.id
       );
       const formatted = await service.format(message.toString());
       interaction.editReply({ ...baseReply, content: formatted });
@@ -26,6 +26,4 @@ const FormatCommand: Command<COMMAND_TYPE.SLASH> = {
       });
     }
   },
-};
-
-export default FormatCommand;
+});

--- a/src/lib/commands/format.ts
+++ b/src/lib/commands/format.ts
@@ -5,8 +5,7 @@ import { createCommand } from '../util/createCommand';
 
 export default createCommand({
   name: 'Format',
-  description: '',
-  type: 'CHAT_INPUT',
+  type: 'MESSAGE',
   async execute(interaction, container) {
     // Get service
     const service = container.getByKey<FormatService>(DITypes.formatService);
@@ -15,7 +14,7 @@ export default createCommand({
     // Parse package.json first
     try {
       const message = await interaction.channel.messages.fetch(
-        interaction.user.id
+        interaction.targetId
       );
       const formatted = await service.format(message.toString());
       interaction.editReply({ ...baseReply, content: formatted });

--- a/src/lib/commands/formatSlash.ts
+++ b/src/lib/commands/formatSlash.ts
@@ -1,12 +1,12 @@
 import { InteractionReplyOptions, Message } from 'discord.js';
 import { DITypes } from '../container/container';
 import { languageMappings } from '../formatters/FormatterMappings';
-import { COMMAND_TYPE, Command } from '../interfaces/ICommand';
 import { FormatService } from '../service/FormatService';
+import { createCommand } from '../util/createCommand';
 
-const FormatSlashCommand: Command<COMMAND_TYPE.CHANNEL> = {
+export default createCommand({
   name: 'format',
-  type: COMMAND_TYPE.CHANNEL,
+  type: 'CHAT_INPUT',
   description: "Formats a message that's given as an argument",
   options: [
     {
@@ -71,6 +71,4 @@ const FormatSlashCommand: Command<COMMAND_TYPE.CHANNEL> = {
       });
     }
   },
-};
-
-export default FormatSlashCommand;
+});

--- a/src/lib/commands/help.ts
+++ b/src/lib/commands/help.ts
@@ -1,10 +1,10 @@
 import { MessageEmbed } from 'discord.js';
-import { Command, COMMAND_TYPE } from '../interfaces/ICommand';
+import { createCommand } from '../util/createCommand';
 
-const HelpCommand: Command<COMMAND_TYPE.LEGACY> = {
+export default createCommand({
   name: 'help',
   description: 'Shows help information',
-  type: COMMAND_TYPE.LEGACY,
+  type: 'LEGACY',
   async execute(message) {
     const embed: Partial<MessageEmbed> = {
       fields: [
@@ -24,6 +24,4 @@ const HelpCommand: Command<COMMAND_TYPE.LEGACY> = {
     };
     message.reply({ embeds: [embed] });
   },
-};
-
-export default HelpCommand;
+});

--- a/src/lib/commands/status.ts
+++ b/src/lib/commands/status.ts
@@ -1,12 +1,12 @@
 import { intervalToDuration } from 'date-fns';
 import { Client, MessageEmbed } from 'discord.js';
-import { Command, COMMAND_TYPE } from '../interfaces/ICommand';
+import { createCommand } from '../util/createCommand';
 
-const StatusCommand: Command<COMMAND_TYPE.LEGACY> = {
+export default createCommand({
   name: 'status',
   description: "Shows FormatBot's status",
-  type: COMMAND_TYPE.LEGACY,
-  async execute(message, container) {
+  type: 'LEGACY',
+  async execute(message, _args, container) {
     // Get dependencies
     const client = container.getByKey<Client>('client');
 
@@ -68,8 +68,6 @@ const StatusCommand: Command<COMMAND_TYPE.LEGACY> = {
     };
     message.reply({ embeds: [embed] });
   },
-};
+});
 
 const createIssueLink = (url: string) => `${url}/issues/new`;
-
-export default StatusCommand;

--- a/src/lib/commands/tex.ts
+++ b/src/lib/commands/tex.ts
@@ -1,12 +1,11 @@
 import { InteractionReplyOptions } from 'discord.js';
 import { DITypes } from '../container/container';
-import { COMMAND_TYPE } from '../interfaces/ICommand';
 import { LaTeXService } from '../service/LaTeXService';
 import { createCommand } from '../util/createCommand';
 
 const LaTeXCommand = createCommand({
   name: 'tex',
-  type: COMMAND_TYPE.CHANNEL,
+  type: 'CHAT_INPUT',
   description: 'Formats LaTeX',
   options: [
     {

--- a/src/lib/interfaces/ICommand.ts
+++ b/src/lib/interfaces/ICommand.ts
@@ -1,62 +1,39 @@
 import {
-  Awaited,
+  ApplicationCommandData,
+  BaseCommandInteraction,
+  ChatInputApplicationCommandData,
   CommandInteraction,
-  CommandInteractionOption,
   ContextMenuInteraction,
   Message,
+  MessageApplicationCommandData,
+  UserApplicationCommandData,
 } from 'discord.js';
 import { Container } from '../container/container';
 
-type ArgsType<T> = T extends Array<infer U>
-  ? U extends void
-    ? []
-    : U extends unknown
-    ? [string[]]
-    : [T]
-  : [];
+type ApplicationCommandBase<T extends BaseCommandInteraction> =
+  ApplicationCommandData & {
+    execute(interaction: T, container: Container): Promise<unknown>;
+  };
 
-// These type alias are necessary because inline declarations
-// clash between prettier and eslint
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type CommandReturnType = any;
+export type ContextMenuCommand = ApplicationCommandBase<
+  ContextMenuInteraction<'cached'>
+> &
+  (UserApplicationCommandData | MessageApplicationCommandData);
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-type EmptyObject = {};
+export type SlashCommand = ApplicationCommandBase<
+  CommandInteraction<'cached'>
+> &
+  ChatInputApplicationCommandData;
 
-interface ICommandWithArgs<TArgs> {
-  resolveArgs(message: Message, args: string[]): Promise<TArgs>;
-}
-
-export type Command<
-  TCommandType extends typeof COMMAND_TYPE[keyof typeof COMMAND_TYPE],
-  TArgs = void
-> = {
+export type LegacyCommand = {
   name: string;
   description: string;
-  type: TCommandType;
-  options?: CommandOption[];
+  type: 'LEGACY';
   execute(
-    ...args: [...args: IMapped<TArgs>[TCommandType], container: Container]
-  ): Awaited<CommandReturnType>;
-} & (TArgs extends void
-  ? EmptyObject
-  : TCommandType extends COMMAND_TYPE.LEGACY
-  ? ICommandWithArgs<TArgs>
-  : EmptyObject);
+    message: Message,
+    args: string[],
+    container: Container
+  ): unknown | Promise<unknown>;
+};
 
-export enum COMMAND_TYPE {
-  LEGACY = 'LEGACY',
-  SLASH = 'MESSAGE',
-  CHANNEL = 'CHAT_INPUT',
-}
-
-export interface CommandOption extends CommandInteractionOption {
-  required?: boolean;
-  description: string;
-}
-
-interface IMapped<TArgs> {
-  [COMMAND_TYPE.CHANNEL]: [interaction: CommandInteraction];
-  [COMMAND_TYPE.SLASH]: [interaction: ContextMenuInteraction];
-  [COMMAND_TYPE.LEGACY]: [message: Message, ...args: ArgsType<TArgs>];
-}
+export type Command = ContextMenuCommand | SlashCommand | LegacyCommand;

--- a/src/lib/util/createCommand.ts
+++ b/src/lib/util/createCommand.ts
@@ -1,10 +1,5 @@
-import { COMMAND_TYPE, Command } from '../interfaces/ICommand';
+import { Command } from '../interfaces/ICommand';
 
-export const createCommand = <
-  TCommandType extends typeof COMMAND_TYPE[keyof typeof COMMAND_TYPE],
-  TArgs = void
->(
-  cmd: Command<TCommandType, TArgs>
-) => {
+export const createCommand = (cmd: Command) => {
   return cmd;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -863,21 +863,21 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@discordjs/builders@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@discordjs/builders/-/builders-0.5.0.tgz#646cbea9cc67f68639e6fb70ed1278b26dacdb14"
-  integrity sha512-HP5y4Rqw68o61Qv4qM5tVmDbWi4mdTFftqIOGRo33SNPpLJ1Ga3KEIR2ibKofkmsoQhEpLmopD1AZDs3cKpHuw==
+"@discordjs/builders@^0.8.1":
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/@discordjs/builders/-/builders-0.8.2.tgz#c3ef99caa9ebe70a4196b987011d90136c71054a"
+  integrity sha512-/YRd11SrcluqXkKppq/FAVzLIPRVlIVmc6X8ZklspzMIHDtJ+A4W37D43SHvLdH//+NnK+SHW/WeOF4Ts54PeQ==
   dependencies:
-    "@sindresorhus/is" "^4.0.1"
-    discord-api-types "^0.22.0"
+    "@sindresorhus/is" "^4.2.0"
+    discord-api-types "^0.24.0"
     ow "^0.27.0"
     ts-mixer "^6.0.0"
-    tslib "^2.3.0"
+    tslib "^2.3.1"
 
-"@discordjs/collection@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@discordjs/collection/-/collection-0.2.1.tgz#ea4bc7b41b7b7b6daa82e439141222ec95c469b2"
-  integrity sha512-vhxqzzM8gkomw0TYRF3tgx7SwElzUlXT/Aa41O7mOcyN6wIJfj5JmDWaO5XGKsGSsNx7F3i5oIlrucCCWV1Nog==
+"@discordjs/collection@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@discordjs/collection/-/collection-0.3.2.tgz#3c271dd8a93dad89b186d330e24dbceaab58424a"
+  integrity sha512-dMjLl60b2DMqObbH1MQZKePgWhsNe49XkKBZ0W5Acl5uVV43SN414i2QfZwRI7dXAqIn8pEWD2+XXQFn9KWxqg==
 
 "@discordjs/form-data@^3.0.1":
   version "3.0.1"
@@ -1140,17 +1140,17 @@
   resolved "https://registry.npmjs.org/@prisma/engines/-/engines-2.29.0-34.1be4cd60b89afa04b192acb1ef47758a39810f3a.tgz"
   integrity sha512-cgEoGK3dmKZkMp/sRbL8TsuVS50rHXYBHk2NY18DPUGr5//4ICno46EjzlayqAFVak8J6RtWZEs+8tE8j8frAQ==
 
-"@sapphire/async-queue@^1.1.4":
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/@sapphire/async-queue/-/async-queue-1.1.4.tgz#ae431310917a8880961cebe8e59df6ffa40f2957"
-  integrity sha512-fFrlF/uWpGOX5djw5Mu2Hnnrunao75WGey0sP0J3jnhmrJ5TAPzHYOmytD5iN/+pMxS+f+u/gezqHa9tPhRHEA==
+"@sapphire/async-queue@^1.1.8":
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@sapphire/async-queue/-/async-queue-1.1.9.tgz#ce69611c8753c4affd905a7ef43061c7eb95c01b"
+  integrity sha512-CbXaGwwlEMq+l1TRu01FJCvySJ1CEFKFclHT48nIfNeZXaAAmmwwy7scUKmYHPUa3GhoMp6Qr1B3eAJux6XgOQ==
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz"
   integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
 
-"@sindresorhus/is@^4.0.1":
+"@sindresorhus/is@^4.0.1", "@sindresorhus/is@^4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.2.0.tgz#667bfc6186ae7c9e0b45a08960c551437176e1ca"
   integrity sha512-VkE3KLBmJwcCaVARtQpfuKcKv8gcBmUubrfHGF84dXuuW6jgsRYxPtzcIhPyK9WAPpRt2/xY6zkD9MnRaJzSyw==
@@ -1288,6 +1288,14 @@
   resolved "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
+"@types/node-fetch@^2.5.12":
+  version "2.5.12"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.12.tgz#8a6f779b1d4e60b7a57fb6fd48d84fb545b9cc66"
+  integrity sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
 "@types/node@*":
   version "16.9.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.9.4.tgz#a12f0ee7847cf17a97f6fdf1093cb7a9af23cca4"
@@ -1328,10 +1336,10 @@
   resolved "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz"
   integrity sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==
 
-"@types/ws@^7.4.7":
-  version "7.4.7"
-  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-7.4.7.tgz#f7c390a36f7a0679aa69de2d501319f4f8d9b702"
-  integrity sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==
+"@types/ws@^8.2.0":
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.2.1.tgz#7bdf6b12869726c9f3cc3c48485efea5d4505274"
+  integrity sha512-SqQ+LhVZaJi7c7sYVkjWALDigi/Wy7h7Iu72gkQp8Y8OWw/DddEVBrTSKu86pQftV2+Gm8lYM61hadPKqyaIeg==
   dependencies:
     "@types/node" "*"
 
@@ -2890,24 +2898,25 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-discord-api-types@^0.22.0:
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/discord-api-types/-/discord-api-types-0.22.0.tgz#34dc57fe8e016e5eaac5e393646cd42a7e1ccc2a"
-  integrity sha512-l8yD/2zRbZItUQpy7ZxBJwaLX/Bs2TGaCthRppk8Sw24LOIWg12t9JEreezPoYD0SQcC2htNNo27kYEpYW/Srg==
+discord-api-types@^0.24.0:
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/discord-api-types/-/discord-api-types-0.24.0.tgz#9e429b8a1ddb4147134dfb3109093422de7ec549"
+  integrity sha512-X0uA2a92cRjowUEXpLZIHWl4jiX1NsUpDhcEOpa1/hpO1vkaokgZ8kkPtPih9hHth5UVQ3mHBu/PpB4qjyfJ4A==
 
-discord.js@^13.1.0:
-  version "13.1.0"
-  resolved "https://registry.yarnpkg.com/discord.js/-/discord.js-13.1.0.tgz#99f6a2a8be88d31906ff0148e9b1cb603ebb2e2e"
-  integrity sha512-gxO4CXKdHpqA+WKG+f5RNnd3srTDj5uFJHgOathksDE90YNq/Qijkd2WlMgTTMS6AJoEnHxI7G9eDQHCuZ+xDA==
+discord.js@^13.3.1:
+  version "13.3.1"
+  resolved "https://registry.yarnpkg.com/discord.js/-/discord.js-13.3.1.tgz#94fe05bc3ec0a3e4761e4f312a2a418c29721ab6"
+  integrity sha512-zn4G8tL5+tMV00+0aSsVYNYcIfMSdT2g0nudKny+Ikd+XKv7m6bqI7n3Vji0GIRqXDr5ArPaw+iYFM2I1Iw3vg==
   dependencies:
-    "@discordjs/builders" "^0.5.0"
-    "@discordjs/collection" "^0.2.1"
+    "@discordjs/builders" "^0.8.1"
+    "@discordjs/collection" "^0.3.2"
     "@discordjs/form-data" "^3.0.1"
-    "@sapphire/async-queue" "^1.1.4"
-    "@types/ws" "^7.4.7"
-    discord-api-types "^0.22.0"
+    "@sapphire/async-queue" "^1.1.8"
+    "@types/node-fetch" "^2.5.12"
+    "@types/ws" "^8.2.0"
+    discord-api-types "^0.24.0"
     node-fetch "^2.6.1"
-    ws "^7.5.1"
+    ws "^8.2.3"
 
 doctrine@^2.1.0:
   version "2.1.0"
@@ -7154,7 +7163,7 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.3.0:
+tslib@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
@@ -7596,10 +7605,10 @@ ws@^7.4.6:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.4.tgz#56bfa20b167427e138a7795de68d134fe92e21f9"
   integrity sha512-zP9z6GXm6zC27YtspwH99T3qTG7bBFv2VIkeHstMLrLlDJuzA7tQ5ls3OJ1hOGGCzTQPniNJoHXIAOS0Jljohg==
 
-ws@^7.5.1:
-  version "7.5.5"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.5.tgz#8b4bc4af518cfabd0473ae4f99144287b33eb881"
-  integrity sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==
+ws@^8.2.3:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.3.0.tgz#7185e252c8973a60d57170175ff55fdbd116070d"
+  integrity sha512-Gs5EZtpqZzLvmIM59w4igITU57lrtYVFneaa434VROv4thzJyV6UjIL3D42lslWlI+D4KzLYnxSwtfuiO79sNw==
 
 xdg-basedir@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
feature

- **What is the current behavior?**
Currently custom declarations are written for different types of commands while the discord.js library allows to differentiate based on the `type` discriminant

- **What is the new behavior (if this is a feature change)?**
- Updated discord.js to pull latest typings
- Made all commands use `createCommand`
- Updated `Command` type

- **Other information**:
Tests succeed and build too, please do test runtime behaviour
