### PR TITLE
fix: cleaned up message parser

### DIFF
--- a/src/lib/config/regex.ts
+++ b/src/lib/config/regex.ts
@@ -1,0 +1,19 @@
+import { languageMappings } from '../formatters/FormatterMappings';
+
+export const regexConfig = {
+  codeBlockRegex: new RegExp(
+    '' + // Prettier hack lol
+      // Match first 3 backticks
+      '```' +
+      // Match language identifier
+      // Will not match if there's no content after the identifier to mimic Discord's behavior
+      '(?<lang>' +
+      Object.keys(languageMappings).join('|') +
+      '(?=\\n[^`{3}]))?' +
+      // Match content
+      '(?<content>.*?)' +
+      // Match last 3 backticks
+      '```',
+    'sg'
+  ),
+};


### PR DESCRIPTION
- **What kind of change does this PR introduce?** Code refactoring

- **What is the current behavior?** Currently the message parser does not take advantage of named regex capture groups and uses messy ways of extracting data from code blocks.

- **What is the new behavior (if this is a feature change)?** No breaking behavior - just refactoring.

- **Other information**: I noticed while working on this PR that the project currently does not isolate type definitions into their own files. Might fix that later on if I have more time.
